### PR TITLE
Change dependency version to 6.5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:6.5.0'
+        classpath 'org.owasp:dependency-check-gradle:6.5.0.1'
     }
 }
 
@@ -61,7 +61,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.5.0'
+    classpath 'org.owasp:dependency-check-gradle:6.5.0.1'
   }
 }
 
@@ -78,7 +78,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.5.0'
+    classpath 'org.owasp:dependency-check-gradle:6.5.0.1'
   }
 }
 
@@ -107,7 +107,7 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "6.2.2" apply false 
+    id("org.owasp.dependencycheck") version "6.5.0.1" apply false 
 }
 
 allprojects {


### PR DESCRIPTION
Hello! Didn't find version 6.5.0 on [Maven central](https://mvnrepository.com/artifact/org.owasp/dependency-check-gradle)
<img width="1175" alt="Screenshot 2021-11-22 at 14 52 12" src="https://user-images.githubusercontent.com/7294857/142857125-989ee911-42b0-4b30-aaef-98c64dec1502.png">
