### PR TITLE
Correct Use of Engine.scan()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:6.5.0.1'
+        classpath 'org.owasp:dependency-check-gradle:6.5.3'
     }
 }
 
@@ -61,7 +61,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.5.0.1'
+    classpath 'org.owasp:dependency-check-gradle:6.5.3'
   }
 }
 
@@ -78,7 +78,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.5.0.1'
+    classpath 'org.owasp:dependency-check-gradle:6.5.3'
   }
 }
 
@@ -107,7 +107,7 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "6.5.0.1" apply false 
+    id("org.owasp.dependencycheck") version "6.5.3" apply false 
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 ext {
-    odcVersion = '6.5.2'
+    odcVersion = '7.0.0-SNAPSHOT'
     slackWebhookVersion = '1.4.0'
     spockCoreVersion = '1.1-groovy-2.4'
 }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -136,6 +136,8 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         def build = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withArguments(taskName)
+                .forwardOutput()
+                .withDebug(true)
                 .withPluginClasspath()
 
         isBuildExpectedToPass ? build.build() : build.buildAndFail()

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckPluginIntegSpec.groovy
@@ -29,6 +29,7 @@ class DependencyCheckPluginIntegSpec extends Specification {
             .withProjectDir(testProjectDir.root)
             .withArguments('tasks')
             .withPluginClasspath()
+            .forwardOutput()
             .build()
 
         then:

--- a/src/test/resources/suppressions.xml
+++ b/src/test/resources/suppressions.xml
@@ -6,5 +6,6 @@
    ]]></notes>
         <gav regex="true">^commons-collections:commons-collections:.*$</gav>
         <cpe>cpe:/a:apache:commons_collections</cpe>
+        <cpe>cpe:/a:apache:james</cpe>
     </suppress>
 </suppressions>


### PR DESCRIPTION
* Fixes issue #239 
* Improves performance on large gradle projects

The PR will likely fail due to lack of config for snapshot build dependencies.