### PR TITLE
Fix virtual path

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -506,7 +506,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         String sha256
         if (file == null) {
             logger.debug("Adding virtual dependency for ${display}")
-            dependency = new Dependency(new File(project.buildDir.getParentFile(), "build.gradle"), true)
+            dependency = new Dependency(new File(project.buildFile), true)
         } else {
             logger.debug("Adding dependency for ${display}")
             dependency = new Dependency(file)


### PR DESCRIPTION
Fixes #172

Use `project.buildFile` as opposed to pointing to the possibly wrong file when scanning.