### PR TITLE
Add option to specify OSS Index URL

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
@@ -33,4 +33,8 @@ class OssIndexExtension {
      * The optional password or API token to connect to the OSS Index
      */
     String password
+    /**
+     * The OSS Index URL.
+     */
+    String url
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -116,6 +116,7 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_ENABLED, config.analyzers.ossIndex.enabled)
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_USER, config.analyzers.ossIndex.username)
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_PASSWORD, config.analyzers.ossIndex.password)
+        settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_URL, config.analyzers.ossIndex.url)
 
         settings.setBooleanIfNotNull(ANALYZER_CENTRAL_ENABLED, config.analyzers.centralEnabled)
 


### PR DESCRIPTION
Add option to specify OSS Index URL - useful for onprem mirrors/proxies in corporate environment.

Exposes functionality available in maven plugin by using the `<ossindexAnalyzerUrl>` parameter.