### PR TITLE
Fix support for old gradle versions

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -402,9 +402,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
             def dependencies = engine.scan(artifact.getFile())
             addInfoToDependencies(dependencies, configuration.name,
-                    artifact.moduleVersion.id.group,
-                    artifact.moduleVersion.id.name,
-                    artifact.moduleVersion.id.version)
+                    artifact.moduleVersion.getId())
         }
     }
 


### PR DESCRIPTION
Per #281 when `addInfoToDependencies` was updated one call was missed. This PR corrects the oversight and allows ODC to be used on older versions of gradle.