### PR TITLE
feat: scan buildEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dependency-Check-Gradle
 ![Build and Deploy](https://github.com/jeremylong/dependency-check-gradle/workflows/Build%20and%20Deploy/badge.svg)
 
 The dependency-check gradle plugin allows projects to monitor dependent libraries for
-known, published vulnerabilities.
+known, published vulnerrabilities.
 
 ## Current Release
 The latest version is 
@@ -24,7 +24,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:7.4.2'
+        classpath 'org.owasp:dependency-check-gradle:7.4.3'
     }
 }
 
@@ -61,7 +61,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:7.4.2'
+    classpath 'org.owasp:dependency-check-gradle:7.4.3'
   }
 }
 
@@ -78,7 +78,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:7.4.2'
+    classpath 'org.owasp:dependency-check-gradle:7.4.3'
   }
 }
 
@@ -107,7 +107,7 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "7.4.2" apply false 
+    id("org.owasp.dependencycheck") version "7.4.3" apply false 
 }
 
 allprojects {

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:7.4.3'
+        classpath 'org.owasp:dependency-check-gradle:8.0.0'
     }
 }
 
@@ -61,7 +61,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:7.4.3'
+    classpath 'org.owasp:dependency-check-gradle:8.0.0'
   }
 }
 
@@ -78,7 +78,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:7.4.3'
+    classpath 'org.owasp:dependency-check-gradle:8.0.0'
   }
 }
 
@@ -107,7 +107,7 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "7.4.3" apply false 
+    id("org.owasp.dependencycheck") version "8.0.0" apply false 
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,14 @@
  */
 
 ext {
-    odcVersion = '7.4.3'
+    odcVersion = '8.0.0-SNAPSHOT'
     slackWebhookVersion = '1.4.0'
     spockCoreVersion = '1.1-groovy-2.4'
 }
 
 group = 'org.owasp'
-version = "${odcVersion}"
+//version = "${odcVersion}"
+version = "8.0.0-RC1"
 
 buildscript {
     repositories {
@@ -72,6 +73,8 @@ dependencies {
         exclude module: 'groovy-all'
     }
 }
+
+test.onlyIf { !project.hasProperty('skipTests') }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,7 @@ ext {
 }
 
 group = 'org.owasp'
-//version = "${odcVersion}"
-version = "8.0.0-RC1"
+version = "${odcVersion}"
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 ext {
-    odcVersion = '7.4.2'
+    odcVersion = '7.4.3'
     slackWebhookVersion = '1.4.0'
     spockCoreVersion = '1.1-groovy-2.4'
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
@@ -30,7 +30,6 @@ class AnalyzerExtension {
     }
 
     Project project;
-
     /**
      * Sets whether the experimental analyzers will be used.
      */

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Project
 /**
  * The analyzer configuration extension. Any value not configured will use the dependency-check-core defaults.
  */
+@groovy.transform.CompileStatic
 class AnalyzerExtension {
 
     AnalyzerExtension(Project project) {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/ArtifactoryExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/ArtifactoryExtension.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle.extension
 /**
  * The artifactory analyzer configuration.
  */
+@groovy.transform.CompileStatic
 class ArtifactoryExtension {
     /**
      * Sets whether the Artifactory Analyzer should be used.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CacheExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CacheExtension.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle.extension
 /**
  * The configuration for caching external results.
  */
+@groovy.transform.CompileStatic
 class CacheExtension {
     /**
      * Sets whether the OSS Index Analyzer's results should be cached locally.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CveExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/CveExtension.groovy
@@ -18,6 +18,7 @@
 
 package org.owasp.dependencycheck.gradle.extension
 
+@groovy.transform.CompileStatic
 class CveExtension {
     /**
      * URL for the modified NVD CVE json data feed:

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DataExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DataExtension.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Project
 /**
  * The update data configuration extension. Any value not configured will use the dependency-check-core defaults.
  */
+@groovy.transform.CompileStatic
 class DataExtension {
     
     DataExtension(Project project) {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -18,8 +18,9 @@
 
 package org.owasp.dependencycheck.gradle.extension
 
-
 import org.gradle.api.Project
+
+import java.util.stream.Collectors
 
 import static org.owasp.dependencycheck.reporting.ReportGenerator.Format
 
@@ -30,6 +31,7 @@ import static org.owasp.dependencycheck.reporting.ReportGenerator.Format
  * @author Jeremy Long
  */
 
+@groovy.transform.CompileStatic
 class DependencyCheckExtension {
 
     DependencyCheckExtension(Project project) {
@@ -85,13 +87,19 @@ class DependencyCheckExtension {
     /**
      * The list of paths to suppression files.
      */
-    List<String> suppressionFiles = []
+    Collection<String> suppressionFiles;
+
+    public void setSuppressionFiles(java.lang.Object[] files) {
+        if (files != null) {
+            suppressionFiles = Arrays.stream(files).map({ o -> o.toString() }).collect(Collectors.toSet())
+        }
+    }
     /**
-     * The username for downloading the suppresion file(s)
+     * The username for downloading the suppression file(s)
      */
     String suppressionFileUser
     /**
-     * The password for downloading the suppresion file(s)
+     * The password for downloading the suppression file(s)
      */
     String suppressionFilePassword
     /**
@@ -132,12 +140,12 @@ class DependencyCheckExtension {
      * Specifies if the build should be failed if a CVSS score above a specified level is identified. The default is
      * 11 which means since the CVSS scores are 0-10, by default the build will never fail.
      */
-    Float failBuildOnCVSS = 11.0
+    Float failBuildOnCVSS = 11.0f
     /**
      * Specifies the CVSS score that should be considered a failure when generating a JUNIT formatted report. The default
      * is 0.0 which means all identified vulnerabilities would be considered a failure.
      */
-    Float junitFailOnCVSS = 0.0
+    Float junitFailOnCVSS = 0.0f
     /**
      * Displays a summary of the findings. Defaults to true.
      */

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -42,6 +42,14 @@ class DependencyCheckExtension {
     Project project;
 
     /**
+     * Whether the buildEnv should be analyzed.
+     */
+    Boolean scanBuildEnv = false
+    /**
+     * Whether the dependencies should be analyzed.
+     */
+    Boolean scanDependencies = true
+    /**
      * The configuration extension for proxy settings.
      */
     ProxyExtension proxy = new ProxyExtension()

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NodeAuditExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NodeAuditExtension.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle.extension
 /**
  * The configuration for the Node Audit Analyzer.
  */
+@groovy.transform.CompileStatic
 class NodeAuditExtension {
     /**
      * Sets whether the Node Audit Analyzer should be used.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle.extension
 /**
  * The configuration for the OSS Index Analyzer.
  */
+@groovy.transform.CompileStatic
 class OssIndexExtension {
     /**
      * Sets whether the OSS Index Analyzer should be used.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/ProxyExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/ProxyExtension.groovy
@@ -22,6 +22,7 @@ package org.owasp.dependencycheck.gradle.extension
  * https://docs.gradle.org/current/userguide/build_environment.html
  */
 @Deprecated
+@groovy.transform.CompileStatic
 class ProxyExtension {
     String server
     Integer port

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/RetireJSExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/RetireJSExtension.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle.extension
 /**
  * The configuration for the RetireJS Analyzer.
  */
+@groovy.transform.CompileStatic
 class RetireJSExtension {
     /**
      * Sets whether the RetireJS Analyzer should be used.

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/SlackExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/SlackExtension.groovy
@@ -20,6 +20,7 @@ package org.owasp.dependencycheck.gradle.extension
 /**
  * The configuration for the Node Audit Analyzer.
  */
+@groovy.transform.CompileStatic
 class SlackExtension {
     Boolean enabled
     String webhookUrl

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/service/SlackNotificationSenderService.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/service/SlackNotificationSenderService.groovy
@@ -6,9 +6,11 @@ import net.gpedro.integrations.slack.SlackAttachment
 import net.gpedro.integrations.slack.SlackException
 import net.gpedro.integrations.slack.SlackMessage
 import org.apache.commons.lang3.StringUtils
+import org.owasp.dependencycheck.utils.Settings
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+@groovy.transform.CompileStatic
 class SlackNotificationSenderService {
     private static final Logger LOGGER = LoggerFactory.getLogger(SlackNotificationSenderService.class);
     public static final String SLACK__WEBHOOK__ENABLED = "SLACK_WEBHOOK_ENABLED"
@@ -17,7 +19,7 @@ class SlackNotificationSenderService {
     private boolean enabled = false
     private String webhookUrl
 
-    SlackNotificationSenderService(def settings) {
+    SlackNotificationSenderService(Settings settings) {
         def enabled = settings.getBoolean(SLACK__WEBHOOK__ENABLED)
         def webhookUrl = settings.getString(SLACK__WEBHOOK__URL)
         if (enabled) {

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -18,12 +18,18 @@
 
 package org.owasp.dependencycheck.gradle.tasks
 
+import com.github.packageurl.PackageURL
+import com.github.packageurl.PackageURLBuilder
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -39,12 +45,10 @@ import org.owasp.dependencycheck.exception.ReportException
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
 import org.owasp.dependencycheck.utils.SeverityUtil
 
-import java.util.stream.Collectors
-
-import static org.owasp.dependencycheck.dependency.EvidenceType.*
+import static org.owasp.dependencycheck.dependency.EvidenceType.PRODUCT
+import static org.owasp.dependencycheck.dependency.EvidenceType.VENDOR
 import static org.owasp.dependencycheck.reporting.ReportGenerator.Format
 import static org.owasp.dependencycheck.utils.Checksum.*
-
 /**
  * Checks the projects dependencies for known vulnerabilities.
  */
@@ -71,7 +75,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         }
         verifySettings()
         initializeSettings()
-        def engine = null
+        Engine engine = null
         try {
             engine = new Engine(settings)
         } catch (DatabaseException ex) {
@@ -292,12 +296,12 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      */
     def shouldBeSkipped(Configuration configuration) {
         ((IGNORE_NON_RESOLVABLE_SCOPES_GRADLE_VERSION.compareTo(GradleVersion.current()) <= 0 && (
-            "archives".equals(configuration.name) ||
-            "default".equals(configuration.name) ||
-            "runtime".equals(configuration.name) ||
-            "compile".equals(configuration.name) ||
-            "compileOnly".equals(configuration.name)))
-        || config.skipConfigurations.contains(configuration.name))
+                "archives".equals(configuration.name) ||
+                        "default".equals(configuration.name) ||
+                        "runtime".equals(configuration.name) ||
+                        "compile".equals(configuration.name) ||
+                        "compileOnly".equals(configuration.name)))
+                || config.skipConfigurations.contains(configuration.name))
     }
 
     /**
@@ -365,6 +369,24 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      * @param project the project to analyze
      * @param engine the dependency-check engine
      */
+    protected void processBuildEnvironment(Project project, Engine engine) {
+        project.getBuildscript().configurations.findAll { Configuration configuration ->
+            shouldBeScanned(configuration) && !(shouldBeSkipped(configuration)
+                    || shouldBeSkippedAsTest(configuration)) && canBeResolved(configuration)
+        }.each { Configuration configuration ->
+            if (CUTOVER_GRADLE_VERSION.compareTo(GradleVersion.current()) > 0) {
+                processConfigLegacy configuration, engine
+            } else {
+                processConfigV4 project, configuration, engine, true
+            }
+        }
+    }
+
+    /**
+     * Process the incoming artifacts for the given project's configurations.
+     * @param project the project to analyze
+     * @param engine the dependency-check engine
+     */
     protected void processConfigurations(Project project, Engine engine) {
         project.configurations.findAll { Configuration configuration ->
             shouldBeScanned(configuration) && !(shouldBeSkipped(configuration)
@@ -407,7 +429,64 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         configuration.getResolvedConfiguration().getResolvedArtifacts().collect { ResolvedArtifact artifact ->
             def dependencies = engine.scan(artifact.getFile())
             addInfoToDependencies(dependencies, configuration.name,
-                    artifact.moduleVersion.getId())
+                    artifact.moduleVersion.getId(), null)
+        }
+    }
+
+    //todo add project as an arg for the root node
+    private Map<PackageURL, Set<String>> buildIncludedByMap(Project project, Configuration configuration, boolean scanningBuildEnv) {
+        Map<PackageURL, Set<String>> includedByMap = new HashMap<>()
+        String parent
+        if (scanningBuildEnv) {
+            parent = "${convertIdentifier(project)} (buildEnv)"
+        } else {
+            parent = convertIdentifier(project).toString();
+        }
+
+        configuration.incoming.resolutionResult.root.getDependencies().each {
+            if (it instanceof ResolvedDependencyResult) {
+                ResolvedDependencyResult dr = (ResolvedDependencyResult) it
+                ResolvedComponentResult current = dr.selected
+                PackageURL purl = convertIdentifier(current.id)
+                if (includedByMap.containsKey(purl)) {
+                    includedByMap.get(purl).add(parent)
+                } else {
+                    Set<String> rootParent = new HashSet<>()
+                    rootParent.add(parent)
+                    includedByMap.put(purl, rootParent);
+                }
+
+                String root
+                if (scanningBuildEnv) {
+                    root = "${convertIdentifier(current.id)} (buildEnv)"
+                } else {
+                    root = "${convertIdentifier(current.id)}";
+                }
+                collectDependencyMap(includedByMap, root, current.getDependencies(), 0)
+            } else {
+                //TODO logging?
+            }
+        }
+        return includedByMap
+    }
+
+    private static void collectDependencyMap(Map<PackageURL, Set<String>> includedByMap, String root, Set<DependencyResult> dependencies, int depth) {
+        dependencies.each {
+            if (it instanceof ResolvedDependencyResult) {
+                ResolvedDependencyResult rdr = (ResolvedDependencyResult) it
+                ResolvedComponentResult current = rdr.selected
+                PackageURL purl = convertIdentifier(current.id)
+                if (includedByMap.containsKey(purl)) {
+                    includedByMap.get(purl).add(root)
+                } else {
+                    Set<String> rootParent = new HashSet<>()
+                    rootParent.add(root)
+                    includedByMap.put(purl, rootParent);
+                }
+                if (current.getDependencies() != null && !current.getDependencies().isEmpty() && depth < 1000) {
+                    collectDependencyMap(includedByMap, root, current.getDependencies(), depth + 1)
+                }
+            }
         }
     }
 
@@ -416,11 +495,14 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      * @param project the project to analyze
      * @param configuration a particular configuration of the project to analyze
      * @param engine the dependency-check engine
+     * @param scanningBuildEnv true if scanning the build environment; otherwise false
      */
-    protected void processConfigV4(Project project, Configuration configuration, Engine engine) {
+    protected void processConfigV4(Project project, Configuration configuration, Engine engine, boolean scanningBuildEnv = false) {
         String projectName = project.name
         String scope = "$projectName:$configuration.name"
-
+        if (scanningBuildEnv) {
+            scope += " (buildEnv)"
+        }
         logger.info "- Analyzing ${scope}"
 
         Map<String, ModuleVersionIdentifier> componentVersions = [:]
@@ -433,9 +515,9 @@ abstract class AbstractAnalyze extends ConfiguredTask {
                 logger.warn("Unable to resolve: ${it}")
             }
         }
+        Map<PackageURL, Set<String>> includedByMap = buildIncludedByMap(project, configuration, scanningBuildEnv)
 
         def types = config.analyzedTypes
-
         types.each { type ->
             configuration.incoming.artifactView {
                 lenient true
@@ -445,23 +527,26 @@ abstract class AbstractAnalyze extends ConfiguredTask {
             }.artifacts.findAll {
                 !shouldBeSkipped(it)
             }.each {
+
                 ModuleVersionIdentifier id = componentVersions[it.id.componentIdentifier]
                 if (id == null) {
                     logger.debug "Could not find dependency {'artifact': '${it.id.componentIdentifier}', " +
                             "'file':'${it.file}'}"
                 } else {
                     def deps = engine.scan(it.file, scope)
-                    //if null ODC doesn't have an analyzer for the dependency type - maybe add anyway?
-                    if (deps == null) {
-                        if (it.file.isFile()) {
-                            addDependency(engine, projectName, configuration.name,
-                                    id, it.id.displayName, it.file)
-                        } else {
-                            addDependency(engine, projectName, configuration.name,
-                                    id, it.id.displayName)
-                        }
-                    } else {
-                        addInfoToDependencies(deps, scope, id)
+
+                    //why would we add something we can't analyze?
+//                    if (deps == null) {
+//                        if (it.file.isFile()) {
+//                            addDependency(engine, projectName, configuration.name,
+//                                    id, it.id.displayName, it.file)
+//                        } else {
+//                            addDependency(engine, projectName, configuration.name,
+//                                    id, it.id.displayName)
+//                        }
+//                    } else {s
+                    if (deps != null) {
+                        addInfoToDependencies(deps, scope, id, includedByMap.get(convertIdentifier(id)))
                     }
                 }
             }
@@ -477,19 +562,49 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      * @param version the version number for the artifact coordinates
      */
     protected void addInfoToDependencies(List<Dependency> deps, String configurationName,
-                                         ModuleVersionIdentifier id) {
+                                         ModuleVersionIdentifier id, Set<String> includedBy) {
         if (deps != null) {
             if (deps.size() == 1) {
                 def d = deps.get(0)
                 MavenArtifact mavenArtifact = new MavenArtifact(id.group, id.name, id.version)
                 d.addAsEvidence("gradle", mavenArtifact, Confidence.HIGHEST)
                 d.addProjectReference(configurationName)
+                if (includedBy != null) {
+                    d.addAllIncludedBy(includedBy)
+                }
             } else {
-                deps.forEach { it.addProjectReference(configurationName) }
+                deps.forEach {
+                    it.addProjectReference(configurationName)
+                    if (includedBy != null) {
+                        it.addAllIncludedBy(includedBy)
+                    }
+                }
             }
         }
     }
 
+    private static PackageURL convertIdentifier(Project project) {
+        final PackageURL p
+        if (project.group) {
+            p = new PackageURL("maven", project.group,
+                    project.name, project.version, null, null)
+        } else {
+            p = PackageURLBuilder.aPackageURL().withType("gradle")
+                    .withName(project.name).withVersion(project.version).build()
+        }
+        return p;
+    }
+    private static PackageURL convertIdentifier(ModuleComponentIdentifier id) {
+        final PackageURL p = new PackageURL("maven", id.moduleIdentifier.group,
+                id.moduleIdentifier.name, id.version, null, null);
+        return p;
+
+    }
+    private static PackageURL convertIdentifier(ModuleVersionIdentifier id) {
+        final PackageURL p = new PackageURL("maven", id.group,
+                id.name, id.version, null, null);
+        return p;
+    }
     /**
      * Adds a dependency to the engine. This is used when an artifact is scanned that is not
      * supported by dependency-check (different dependency type for possibly new language).
@@ -552,4 +667,5 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         Object[] methodArgs = ["The gradle-versions-plugin isn't compatible with the configuration cache"]
         metaClass.invokeMethod(this, methodName, methodArgs)
     }
+
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -52,7 +52,12 @@ class Aggregate extends AbstractAnalyze {
     private def scanProject(Set<Project> projects, Engine engine) {
         projects.each { Project project ->
             if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
-                processConfigurations(project, engine)
+                if (this.config.scanDependencies) {
+                    processConfigurations(project, engine)
+                }
+                if (this.config.scanBuildEnv) {
+                    processBuildEnvironment(project, engine)
+                }
             }
         }
     }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Aggregate.groovy
@@ -19,11 +19,13 @@
 package org.owasp.dependencycheck.gradle.tasks
 
 import org.gradle.api.Project
+import org.owasp.dependencycheck.Engine
 import org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 
 /**
  * Checks the projects dependencies for known vulnerabilities.
  */
+@groovy.transform.CompileStatic
 class Aggregate extends AbstractAnalyze {
 
     Aggregate() {
@@ -38,7 +40,7 @@ class Aggregate extends AbstractAnalyze {
     /**
      * Loads the projects dependencies into the dependency-check analysis engine.
      */
-    def scanDependencies(engine) {
+    def scanDependencies(Engine engine) {
         logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
         if (project.rootProject.plugins.hasPlugin(DependencyCheckPlugin)) {
             scanProject(project.rootProject.allprojects, engine)
@@ -47,10 +49,10 @@ class Aggregate extends AbstractAnalyze {
         }
     }
 
-    private def scanProject(Set<Project> projects, engine) {
-        projects.each { Project Project ->
-            if (shouldBeScanned(Project) && !shouldBeSkipped(Project)) {
-                processConfigurations(Project, engine)
+    private def scanProject(Set<Project> projects, Engine engine) {
+        projects.each { Project project ->
+            if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
+                processConfigurations(project, engine)
             }
         }
     }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -17,9 +17,13 @@
  */
 
 package org.owasp.dependencycheck.gradle.tasks
+
+import org.owasp.dependencycheck.Engine
+
 /**
  * Checks the projects dependencies for known vulnerabilities.
  */
+@groovy.transform.CompileStatic
 class Analyze extends AbstractAnalyze {
 
     Analyze() {
@@ -34,7 +38,7 @@ class Analyze extends AbstractAnalyze {
     /**
      * Loads the projects dependencies into the dependency-check analysis engine.
      */
-    def scanDependencies(engine) {
+    def scanDependencies(Engine engine) {
         if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
             logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
             processConfigurations(project, engine)

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Analyze.groovy
@@ -41,7 +41,12 @@ class Analyze extends AbstractAnalyze {
     def scanDependencies(Engine engine) {
         if (shouldBeScanned(project) && !shouldBeSkipped(project)) {
             logger.lifecycle("Verifying dependencies for project ${currentProjectName}")
-            processConfigurations(project, engine)
+            if (this.config.scanDependencies) {
+                processConfigurations(project, engine)
+            }
+            if (this.config.scanBuildEnv) {
+                processBuildEnvironment(project, engine)
+            }
         }
     }
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -22,6 +22,7 @@ import com.google.common.base.Strings
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Internal
+import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
 import org.owasp.dependencycheck.utils.Settings
 
@@ -32,14 +33,15 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.*
  *
  * @author Jeremy Long
  */
+@groovy.transform.CompileStatic
 abstract class ConfiguredTask extends DefaultTask {
 
     @Internal
-    def config = project.dependencyCheck
+    DependencyCheckExtension config = (DependencyCheckExtension) project.getExtensions().findByName('dependencyCheck')
     @Internal
-    def settings
+    Settings settings
     @Internal
-    def PROPERTIES_FILE = 'task.properties'
+    String PROPERTIES_FILE = 'task.properties'
 
     /**
      * Initializes the settings object. If the setting is not set the
@@ -217,11 +219,15 @@ abstract class ConfiguredTask extends DefaultTask {
      *
      * @return an array of suppression file paths
      */
-    private String[] determineSuppressions(suppressionFiles, suppressionFile) {
-        if (suppressionFile != null) {
-            suppressionFiles << suppressionFile
+    private String[] determineSuppressions(Collection<String> suppressionFiles, String suppressionFile) {
+        List<String> files = []
+        if (suppressionFiles != null) {
+            files.addAll(suppressionFiles)
         }
-        suppressionFiles
+        if (suppressionFile != null) {
+            files << suppressionFile
+        }
+        return files.toArray(new String[0])
     }
     /**
      * Selects the current configiguration option - returns the deprecated option if the current configuration option is null

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Purge.groovy
@@ -25,6 +25,7 @@ import org.owasp.dependencycheck.Engine
 /**
  * Purges the local cache of the NVD CVE data.
  */
+@groovy.transform.CompileStatic
 class Purge extends ConfiguredTask {
 
     /**

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/Update.groovy
@@ -32,6 +32,7 @@ import static org.owasp.dependencycheck.utils.Settings.KEYS.AUTO_UPDATE
  *
  * @author Jeremy Long
  */
+@groovy.transform.CompileStatic
 class Update extends ConfiguredTask {
 
     /**
@@ -49,7 +50,7 @@ class Update extends ConfiguredTask {
     update() {
         initializeSettings()
         settings.setBooleanIfNotNull(AUTO_UPDATE, true)
-        def engine = null
+        Engine engine = null
         try {
             engine = new Engine(settings)
             engine.doUpdates()
@@ -75,7 +76,7 @@ class Update extends ConfiguredTask {
     /**
      * Releases resources and removes temporary files used.
      */
-    def cleanup(engine) {
+    def cleanup(Engine engine) {
         if (engine != null) {
             engine.close()
         }

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -135,7 +135,7 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
     private BuildResult executeTaskAndGetResult(String taskName, boolean isBuildExpectedToPass) {
         def build = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(taskName)
+                .withArguments(taskName,"--stacktrace")
                 .forwardOutput()
                 .withDebug(true)
                 .withPluginClasspath()

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -160,7 +160,9 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.skipGroups == ['b']
         project.dependencyCheck.skipTestGroups == false
         project.dependencyCheck.suppressionFile == './src/config/suppression.xml'
-        project.dependencyCheck.suppressionFiles == ['./src/config/suppression1.xml', './src/config/suppression2.xml']
+        project.dependencyCheck.suppressionFiles.getAt(0) == './src/config/suppression2.xml'
+        project.dependencyCheck.suppressionFiles.getAt(1) == './src/config/suppression1.xml'
+        //project.dependencyCheck.suppressionFiles == ['./src/config/suppression1.xml', './src/config/suppression2.xml']
         project.dependencyCheck.suppressionFileUser == 'suppressionFileUsername'
         project.dependencyCheck.suppressionFilePassword == 'suppressionFilePassword'
         project.dependencyCheck.analyzers.artifactory.enabled == true


### PR DESCRIPTION
Resolves #283

- Adds the ability to scan the `buildEnv`
- Adds the new `included by` references in the report to indicate the root parent dependencies that caused a transitive dependency to be included in the project. I.e. not the full dependency-tree - just the root.