### PR TITLE
fix: add missing argument for OSS Index

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/OssIndexExtension.groovy
@@ -38,4 +38,8 @@ class OssIndexExtension {
      * The OSS Index URL.
      */
     String url
+    /**
+     * Only output a warning message instead of failing when remote errors occur.
+     */
+    Boolean warnOnlyOnRemoteErrors
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -122,6 +122,7 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setBooleanIfNotNull(ANALYZER_JAR_ENABLED, config.analyzers.jarEnabled)
         settings.setBooleanIfNotNull(ANALYZER_NUSPEC_ENABLED, config.analyzers.nuspecEnabled)
         settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_ENABLED, select(config.analyzers.ossIndex.enabled, config.analyzers.ossIndexEnabled))
+        settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_WARN_ONLY_ON_REMOTE_ERRORS, config.analyzers.ossIndex.warnOnlyOnRemoteErrors)
         settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_ENABLED, config.analyzers.ossIndex.enabled)
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_USER, config.analyzers.ossIndex.username)
         settings.setStringIfNotEmpty(ANALYZER_OSSINDEX_PASSWORD, config.analyzers.ossIndex.password)


### PR DESCRIPTION
Allow gradle users to lesson the impact of hitting the OSS Index Rate Limit by configuring ODC to only produce warning messages instead of throwing an exception.