### PR TITLE
fix: Gradle plugin breaking on ProjectComponentIdentifiers for multimodule projects

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
@@ -596,6 +597,9 @@ abstract class AbstractAnalyze extends ConfiguredTask {
                 id.moduleIdentifier.name, id.version, null, null);
         return p;
 
+    }
+    private static PackageURL convertIdentifier(ProjectComponentIdentifier id) {
+        PackageURLBuilder.newInstance().withType("gradle").withName(id.projectPath).build();
     }
     private static PackageURL convertIdentifier(ModuleVersionIdentifier id) {
         final PackageURL p = new PackageURL("maven", id.group,

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -599,7 +599,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
 
     }
     private static PackageURL convertIdentifier(ProjectComponentIdentifier id) {
-        PackageURLBuilder.newInstance().withType("gradle").withName(id.projectPath).build();
+        PackageURLBuilder.aPackageURL().withType("gradle").withName(id.projectPath).build();
     }
     private static PackageURL convertIdentifier(ModuleVersionIdentifier id) {
         final PackageURL p = new PackageURL("maven", id.group,


### PR DESCRIPTION
## Fixes https://github.com/jeremylong/DependencyCheck/issues/5306

## Description of Change
Adds conversion support for ProjectComponentIdentifiers.

From the limited information available in a ProjectComponentIdentifier I considered the projectPath to be the most usable for generating a packageURL, but I'm open for modifications to what is used for the packageURL (I'm not too familiar with gradle, just enough to be able to code this fix)


