### PR TITLE
Fix groovy.lang.MissingMethodException when scanSet property is used (#315)

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -416,10 +416,11 @@ abstract class AbstractAnalyze extends ConfiguredTask {
             }
         } else {
             config.scanSet.each {
-                if (it.exists()) {
-                    engine.scan(it, project.name)
+                File f = project.file it
+                if (f.exists()) {
+                    engine.scan(f, project.name)
                 } else {
-                    logger.warn("ScanSet file `${it}` does not exist in ${project.name}")
+                    logger.warn("ScanSet file `${f}` does not exist in ${project.name}")
                 }
             }
         }


### PR DESCRIPTION
Fix for #315 

Resolves paths specified in `dependencyCheck.scanSet` using `project.file`. This reverts the scanSet property to the same behaviour as 7.4.0.