### PR TITLE
Use latest dependency check version available

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.1.2'
+        classpath 'org.owasp:dependency-check-gradle:8.3.1'
     }
 }
 
@@ -79,7 +79,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:8.1.2'
+    classpath 'org.owasp:dependency-check-gradle:8.3.1'
   }
 }
 
@@ -108,7 +108,7 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "8.1.2" apply false 
+    id("org.owasp.dependencycheck") version "8.3.1" apply false 
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 ext {
-    odcVersion = '8.1.2'
+    odcVersion = '8.3.1'
     slackWebhookVersion = '1.4.0'
     spockCoreVersion = '1.1-groovy-2.4'
 }


### PR DESCRIPTION
Update to latest dependency check version currently available:
https://github.com/jeremylong/DependencyCheck/releases/tag/v8.3.1

in regards to https://github.com/dependency-check/dependency-check-gradle/issues/342