### PR TITLE
Support ignoring dev dependencies in Node Package analyzer

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
@@ -157,7 +157,9 @@ class AnalyzerExtension {
     Boolean cpanEnabled
     /**
      * Sets whether the Node.js Analyzer should be used.
+     * @deprecated Use nodePackage { enabled = true }
      */
+    @Deprecated
     Boolean nodeEnabled
     /**
      * Sets whether the NSP Analyzer should be used.
@@ -185,6 +187,11 @@ class AnalyzerExtension {
      * The configuration extension for the node audit settings.
      */
     NodeAuditExtension nodeAudit = new NodeAuditExtension()
+
+    /**
+     * The configuration extension for the node package settings.
+     */
+    NodePackageExtension nodePackage = new NodePackageExtension()
 
     /**
      * The configuration extension for artifactory settings.
@@ -230,5 +237,14 @@ class AnalyzerExtension {
      */
     def nodeAudit(Closure configClosure) {
         return project.configure(nodeAudit, configClosure)
+    }
+
+    /**
+     * Allows programmatic configuration of the node package extension
+     * @param configClosure the closure to configure the node extension
+     * @return the node extension
+     */
+    def nodePackage(Closure configClosure) {
+        return project.configure(nodePackage, configClosure)
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NodePackageExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NodePackageExtension.groovy
@@ -1,0 +1,33 @@
+/*
+ * This file is part of dependency-check-gradle.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2019 Jeremy Long. All Rights Reserved.
+ */
+package org.owasp.dependencycheck.gradle.extension
+
+/**
+ * The configuration for the Node Package Analyzer.
+ */
+@groovy.transform.CompileStatic
+class NodePackageExtension {
+    /**
+     * Sets whether the Node Package Analyzer should be used.
+     */
+    Boolean enabled
+    /**
+     * Sets whether the Node Package Analyzer should skip devDependencies.
+     */
+    Boolean skipDevDependencies
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -165,7 +165,8 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setBooleanIfNotNull(ANALYZER_NUGETCONF_ENABLED, config.analyzers.nugetconfEnabled)
 
 
-        settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_ENABLED, config.analyzers.nodeEnabled)
+        settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_ENABLED, select(config.analyzers.nodePackage.enabled, config.analyzers.nodeEnabled))
+        settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_SKIPDEV, config.analyzers.nodePackage.skipDevDependencies)
         settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_ENABLED, select(config.analyzers.nodeAudit.enabled, config.analyzers.nodeAuditEnabled))
         settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_USE_CACHE, config.analyzers.nodeAudit.useCache)
         settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_SKIPDEV, config.analyzers.nodeAudit.skipDevDependencies)


### PR DESCRIPTION
Adds support for the skip dev dependencies flag from the Node Package analyzer.