### PR TITLE
Add the ability to manually specify addtional CPE entries to be checked.

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AdditionalCpe.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AdditionalCpe.groovy
@@ -1,0 +1,29 @@
+package org.owasp.dependencycheck.gradle.extension
+
+import org.gradle.api.Named
+
+/**
+ * Holder for the information regarding an additional CPE to be checked.
+ */
+@groovy.transform.CompileStatic
+class AdditionalCpe implements Named {
+
+  AdditionalCpe(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Name assigned to the CPE entry during configuration.
+   */
+  String name;
+
+  /**
+   * Description for the what the CPE represents.
+   */
+  String description
+
+  /**
+   * The CPE to be checked against the database.
+   */
+  String cpe
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -18,6 +18,8 @@
 
 package org.owasp.dependencycheck.gradle.extension
 
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 import java.util.stream.Collectors
@@ -210,11 +212,17 @@ class DependencyCheckExtension {
      * A set of files or folders to scan.
      */
     List<File> scanSet
+    /**
+     * Additional CPE to be analyzed.
+     */
+    NamedDomainObjectContainer<AdditionalCpe> additionalCpes =
+            project.objects.domainObjectContainer(AdditionalCpe.class)
 
     /**
      * The configuration extension for cache settings.
      */
     CacheExtension cache = new CacheExtension()
+
 
     /**
      * Allows programmatic configuration of the proxy extension
@@ -277,5 +285,13 @@ class DependencyCheckExtension {
      */
     def cache(Closure configClosure) {
         return project.configure(cache, configClosure)
+    }
+
+    /**
+     * Allows programmatic configuration of additional CPEs to be analyzed
+     * @param action the action used to add entries to additional CPEs container.
+     */
+    def additionalCpes(Action<NamedDomainObjectContainer<AdditionalCpe>> action) {
+        action.execute(additionalCpes)
     }
 }

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -43,10 +43,12 @@ import org.owasp.dependencycheck.dependency.Confidence
 import org.owasp.dependencycheck.dependency.Dependency
 import org.owasp.dependencycheck.dependency.IncludedByReference
 import org.owasp.dependencycheck.dependency.Vulnerability
+import org.owasp.dependencycheck.dependency.naming.CpeIdentifier
 import org.owasp.dependencycheck.exception.ExceptionCollection
 import org.owasp.dependencycheck.exception.ReportException
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
 import org.owasp.dependencycheck.utils.SeverityUtil
+import us.springett.parsers.cpe.CpeParser
 
 import static org.owasp.dependencycheck.dependency.EvidenceType.PRODUCT
 import static org.owasp.dependencycheck.dependency.EvidenceType.VENDOR
@@ -457,6 +459,15 @@ abstract class AbstractAnalyze extends ConfiguredTask {
                     logger.warn("ScanSet file `${f}` does not exist in ${project.name}")
                 }
             }
+        }
+
+        config.additionalCpes.each {
+            var dep = new Dependency(true);
+            dep.setDescription(it.description)
+            dep.addVulnerableSoftwareIdentifier(new CpeIdentifier(CpeParser.parse(it.cpe), Confidence.HIGHEST))
+            dep.setFileName("")
+            dep.setActualFilePath("")
+            engine.addDependency(dep)
         }
     }
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -48,6 +48,7 @@ import org.owasp.dependencycheck.exception.ExceptionCollection
 import org.owasp.dependencycheck.exception.ReportException
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
 import org.owasp.dependencycheck.utils.SeverityUtil
+import org.owasp.dependencycheck.utils.Checksum
 import us.springett.parsers.cpe.CpeParser
 
 import static org.owasp.dependencycheck.dependency.EvidenceType.PRODUCT
@@ -464,6 +465,10 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         config.additionalCpes.each {
             var dep = new Dependency(true);
             dep.setDescription(it.description)
+            dependency.setDisplayFileName(it.cpe);
+            dependency.setSha1sum(Checksum.getSHA1Checksum(it.cpe));
+            dependency.setSha256sum(Checksum.getSHA256Checksum(it.cpe));
+            dependency.setMd5sum(Checksum.getMD5Checksum(it.cpe));
             dep.addVulnerableSoftwareIdentifier(new CpeIdentifier(CpeParser.parse(it.cpe), Confidence.HIGHEST))
             dep.setFileName("")
             dep.setActualFilePath("")

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -463,16 +463,16 @@ abstract class AbstractAnalyze extends ConfiguredTask {
         }
 
         config.additionalCpes.each {
-            var dep = new Dependency(true);
-            dep.setDescription(it.description)
+            var dependency = new Dependency(true);
+            dependency.setDescription(it.description)
             dependency.setDisplayFileName(it.cpe);
             dependency.setSha1sum(Checksum.getSHA1Checksum(it.cpe));
             dependency.setSha256sum(Checksum.getSHA256Checksum(it.cpe));
             dependency.setMd5sum(Checksum.getMD5Checksum(it.cpe));
-            dep.addVulnerableSoftwareIdentifier(new CpeIdentifier(CpeParser.parse(it.cpe), Confidence.HIGHEST))
-            dep.setFileName("")
-            dep.setActualFilePath("")
-            engine.addDependency(dep)
+            dependency.addVulnerableSoftwareIdentifier(new CpeIdentifier(CpeParser.parse(it.cpe), Confidence.HIGHEST))
+            dependency.setFileName("")
+            dependency.setActualFilePath("")
+            engine.addDependency(dependency)
         }
     }
 

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckConfigurationSelectionIntegSpec.groovy
@@ -46,6 +46,19 @@ class DependencyCheckConfigurationSelectionIntegSpec extends Specification {
         //result.output.contains('CVE-2015-5262')
     }
 
+    def "additional CPEs are scanned when present"() {
+        given:
+        copyBuildFileIntoProjectDir('scanAdditionalCpesConfiguration.gradle')
+
+        when:
+        def result = executeTaskAndGetResult(ANALYZE_TASK, false)
+
+        then:
+        result.task(":$ANALYZE_TASK").outcome == FAILED
+        result.output.contains('CVE-2015-6420')
+        result.output.contains('CVE-2016-3092')
+    }
+
     def "custom configurations are scanned by default"() {
         given:
         copyBuildFileIntoProjectDir('scanCustomConfiguration.gradle')

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -148,6 +148,23 @@ class DependencyCheckGradlePluginSpec extends Specification {
             suppressionFiles = ['./src/config/suppression1.xml', './src/config/suppression2.xml']
             suppressionFileUser = 'suppressionFileUsername'
             suppressionFilePassword = 'suppressionFilePassword'
+
+            additionalCpes {
+                additional1 {
+                    description = "Additional1"
+                    cpe = "cpe:2.3:a:aGroup1:aPackage1:123:*:*:*:*:*:*:*"
+                }
+
+                additional2 {
+                    description = "Additional2"
+                    cpe = "cpe:2.3:a:aGroup2:aPackage2:123:*:*:*:*:*:*:*"
+                }
+
+                additional3 {
+                    description = "Additional3"
+                    cpe = "cpe:2.3:a:aGroup3:aPackage3:123:*:*:*:*:*:*:*"
+                }
+            }
         }
 
         then:
@@ -185,6 +202,10 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.analyzers.retirejs.filterNonVulnerable == true
         project.dependencyCheck.slack.enabled == true
         project.dependencyCheck.slack.webhookUrl == slackWebhookUrl
+        project.dependencyCheck.additionalCpes.size() == 3
+        project.dependencyCheck.additionalCpes.getByName('additional1').description == 'Additional1'
+        project.dependencyCheck.additionalCpes.getByName('additional1').cpe == 'cpe:2.3:a:aGroup1:aPackage1:123:*:*:*:*:*:*:*'
+
     }
 
     def 'scanConfigurations and skipConfigurations are mutually exclusive'() {

--- a/src/test/resources/scanAdditionalCpesConfiguration.gradle
+++ b/src/test/resources/scanAdditionalCpesConfiguration.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'org.owasp.dependencycheck'
+    id 'java'
+}
+
+sourceCompatibility = 1.5
+version = '1.0'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 0
+    additionalCpes {
+        commonsCollections {
+            description = "Commons Collections 3.2"
+            cpe = "cpe:2.3:a:apache:commons_collections:3.2:*:*:*:*:*:*:*"
+        }
+        commonsFileUpload {
+            description = "Commons File Upload 1.3.1"
+            cpe = "cpe:2.3:a:apache:commons_fileupload:1.3.1:*:*:*:*:*:*:*"
+        }
+    }
+}


### PR DESCRIPTION
This change allows adding CPEs to be included in analysis for dependencies that might not be picked up during scans.

For example to add in a dependency on PostgresSQL:

```
dependencyCheck {
  additionalCpes {
    postgreSql {
      description = "PostgreSQL"
      cpe = "cpe:2.3:a:postgresql:postgresql:${postgresqlVersion}:*:*:*:*:*:*:*"
     }
  }
}
```