### PR TITLE
fix: set proxy.nonproxyhosts setting as pipe delimited string

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -226,7 +226,7 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setStringIfNotEmpty(PROXY_PORT, "${config.proxy.port}")
         settings.setStringIfNotEmpty(PROXY_USERNAME, config.proxy.username)
         settings.setStringIfNotEmpty(PROXY_PASSWORD, config.proxy.password)
-        settings.setArrayIfNotEmpty(PROXY_NON_PROXY_HOSTS, config.proxy.nonProxyHosts)
+        settings.setStringIfNotEmpty(PROXY_NON_PROXY_HOSTS, config.proxy.nonProxyHosts.join("|"))
     }
 
     /**


### PR DESCRIPTION
The matchNonProxy method in the core utils library expects proxy.nonproxyhosts setting to be a pipe, comma, or semicolon delimited string, but the gradle plugin sets it as an array causing the values to be corrupted when they are read. Use a pipe delimited string instead.

resolves #319