### PR TITLE
feat: Allow configurable resultsPerPage in Gradle plugin

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NvdExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NvdExtension.groovy
@@ -29,6 +29,10 @@ class NvdExtension {
      */
     Integer delay
     /**
+     * The number records for a single page from NVD API (must be <=2000).
+     */
+    Integer resultsPerPage
+    /**
      * The maximum number of retry requests for a single call to the NVD API.
      */
     Integer maxRetryCount

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -91,6 +91,7 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setStringIfNotEmpty(NVD_API_KEY, config.nvd.apiKey)
         settings.setStringIfNotEmpty(NVD_API_ENDPOINT, config.nvd.endpoint)
         settings.setIntIfNotNull(NVD_API_DELAY, config.nvd.delay)
+        settings.setIntIfNotNull(NVD_API_RESULTS_PER_PAGE, config.nvd.resultsPerPage)
         settings.setIntIfNotNull(NVD_API_MAX_RETRY_COUNT, config.nvd.maxRetryCount)
         settings.setIntIfNotNull(NVD_API_VALID_FOR_HOURS, config.nvd.validForHours);
 


### PR DESCRIPTION
Add the configurability of resultsPerPage from https://github.com/jeremylong/DependencyCheck/pull/6843 to the Gradle plugin

Prerequisite for successful build is an update to the version of DependencyCheck that has that PR integrated due to a dependency on the new Settings.KEYS value