### PR TITLE
fix: find regex in test configuration hierarchy check instead of match

### DIFF
--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/AbstractAnalyze.groovy
@@ -377,7 +377,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
      * Checks whether a configuration is considered to be a test configuration in order to skip it.
      * A configuration is considered a test configuration if and only if any of the following conditions holds:
      * <ul>
-     *     <li>the name of the configuration or any of its parent configurations matches /((^|[a-z0-9_])T|(^|_)t)est([A-Z0-9_]|$)/</li>
+     *     <li>the name of the configuration or any of its parent configurations contains a match for /((^|[a-z0-9_])T|(^|_)t)est([A-Z0-9_]|$)/</li>
      * </ul>
      * The intent of the regular expression is to match `test` in a camel case or snake case configuration name.
      */
@@ -385,7 +385,7 @@ abstract class AbstractAnalyze extends ConfiguredTask {
     static boolean isTestConfigurationCheck(Configuration configuration) {
         boolean isTestConfiguration = configuration.name =~ /((^|[a-z0-9_])T|(^|_)t)est([A-Z0-9_]|$)/
         configuration.hierarchy.each {
-            isTestConfiguration |= it.name ==~ /((^|[a-z0-9_])T|(^|_)t)est([A-Z0-9_]|$)/
+            isTestConfiguration |= (it.name =~ /((^|[a-z0-9_])T|(^|_)t)est([A-Z0-9_]|$)/) as boolean
         }
         isTestConfiguration
     }


### PR DESCRIPTION
I guess it was a typo to use `==~` in the hierarchy check which will not find the intended configurations
as then the whole name would need to match. It should probably be `=~` which uses `find` just like in the
configuration name check right above.
