### PR TITLE
fix: resolve initialization problem using ODC-core 11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:10.0.4'
+        classpath 'org.owasp:dependency-check-gradle:11.0.0'
     }
 }
 
@@ -91,7 +91,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:10.0.4'
+    classpath 'org.owasp:dependency-check-gradle:11.0.0'
   }
 }
 
@@ -108,7 +108,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:10.0.4'
+    classpath 'org.owasp:dependency-check-gradle:11.0.0'
   }
 }
 
@@ -137,7 +137,7 @@ subprojects {
 
 ```kotlin
 plugins {
-    id("org.owasp.dependencycheck") version "10.0.4" apply false 
+    id("org.owasp.dependencycheck") version "11.0.0" apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-odc = '10.0.4'
+odc = '11.0.0'
 spock = '2.3-groovy-3.0'
 junit = '5.10.3'
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Internal
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import org.owasp.dependencycheck.gradle.service.SlackNotificationSenderService
+import org.owasp.dependencycheck.utils.Downloader
 import org.owasp.dependencycheck.utils.Settings
 
 import static org.owasp.dependencycheck.utils.Settings.KEYS.*
@@ -158,7 +159,6 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setBooleanIfNotNull(ANALYZER_CPANFILE_ENABLED, config.analyzers.cpanEnabled)
         settings.setBooleanIfNotNull(ANALYZER_NUGETCONF_ENABLED, config.analyzers.nugetconfEnabled)
 
-
         settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_ENABLED, select(config.analyzers.nodePackage.enabled, config.analyzers.nodeEnabled))
         settings.setBooleanIfNotNull(ANALYZER_NODE_PACKAGE_SKIPDEV, config.analyzers.nodePackage.skipDevDependencies)
         settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_ENABLED, select(config.analyzers.nodeAudit.enabled, config.analyzers.nodeAuditEnabled))
@@ -185,6 +185,8 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setBooleanIfNotNull(ANALYZER_NODE_AUDIT_USE_CACHE, config.cache.nodeAudit)
         settings.setBooleanIfNotNull(ANALYZER_CENTRAL_USE_CACHE, config.cache.central)
         settings.setBooleanIfNotNull(ANALYZER_OSSINDEX_USE_CACHE, config.cache.ossIndex)
+
+        Downloader.getInstance().configure(settings);
     }
 
     private void configureSlack(Settings settings) {

--- a/src/test/resources/scanAdditionalCpesConfiguration.gradle
+++ b/src/test/resources/scanAdditionalCpesConfiguration.gradle
@@ -23,4 +23,7 @@ dependencyCheck {
             cpe = "cpe:2.3:a:apache:commons_fileupload:1.3.1:*:*:*:*:*:*:*"
         }
     }
+    nvd {
+        datafeedUrl = 'https://jeremylong.github.io/DependencyCheck/hb_nvd/'
+    }
 }


### PR DESCRIPTION
Somehow the gradle plugin was previously working without configuring the singleton `Downloader`:

```
Downloader.getInstance().configure(settings);
```

The other Maven plugins, Ant tasks, and the CLI all included the above call. 