### PR TITLE
fix: re-enable Central Analyzer by default

### DIFF
--- a/src/main/resources/task.properties
+++ b/src/main/resources/task.properties
@@ -2,5 +2,6 @@
 ### Do not define the path here - it is defined in DataExtension
 ### data.directory=[JAR]/../../dependency-check-data/9.0
 
-# disable the central analyzer by default
-analyzer.central.enabled=false
+# disabling the central analyzer can cause False Negatives because
+# gradle does not download the pom.xml from central by default.
+# analyzer.central.enabled=false


### PR DESCRIPTION
Gradle by default does not download the pom.xml from Central - without this false negatives may be generated.

resolves https://github.com/dependency-check/dependency-check-gradle/issues/421