### PR TITLE
feat: Extend authentication configuration options (including bearer)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-odc = '11.1.1'
+odc = '11.1.2-SNAPSHOT'
 spock = '2.3-groovy-3.0'
 junit = '5.10.3'
 

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
@@ -40,18 +40,6 @@ class AnalyzerExtension {
      */
     Boolean archiveEnabled
     /**
-     * Sets whether the Known Exploited Vulnerability update and Analyzer will be used.
-     */
-    Boolean knownExploitedEnabled
-    /**
-     * URL to the CISA Known Exploited Vulnerabilities JSON data feed.
-     */
-    String knownExploitedURL
-    /**
-     * Controls the skipping of the check for Known Exploited Vulnerabilities updates.
-     */
-    Integer knownExploitedValidForHours
-    /**
      * A comma-separated list of additional file extensions to be treated like a ZIP file, the contents will be extracted and analyzed.
      */
     String zipExtensions
@@ -188,6 +176,11 @@ class AnalyzerExtension {
     Boolean ossIndexEnabled
 
     /**
+     * The configuration extension for known exploited vulnerabilities settings.
+     */
+    KEVExtension kev = new KEVExtension()
+
+    /**
      * The configuration extension for retirejs settings.
      */
     RetireJSExtension retirejs = new RetireJSExtension()
@@ -211,6 +204,27 @@ class AnalyzerExtension {
      * The configuration extension for artifactory settings.
      */
     OssIndexExtension ossIndex = new OssIndexExtension()
+
+    /**
+     * Allows programmatic configuration of the KEV extension
+     * @param configClosure the closure to configure the KEV extension
+     * @return the KEV extension
+     * @deprecated Use the {@code Action} variant instead
+     */
+    @Deprecated
+    def kev(Closure configClosure) {
+        return project.configure(kev, configClosure)
+    }
+
+    /**
+     * Allows programmatic configuration of the KEV extension
+     * @param config the action to configure the KEV extension
+     * @return the KEV extension
+     */
+    def kev(Action<KEVExtension> config) {
+        config.execute(kev)
+        return kev
+    }
 
     /**
      * Allows programmatic configuration of the retirejs extension

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/DependencyCheckExtension.groovy
@@ -111,13 +111,17 @@ class DependencyCheckExtension {
         }
     }
     /**
-     * The username for downloading the suppression file(s)
+     * The username for downloading the suppression file(s) from HTTP Basic protected locations
      */
     String suppressionFileUser
     /**
-     * The password for downloading the suppression file(s)
+     * The password for downloading the suppression file(s) from HTTP Basic protected locations
      */
     String suppressionFilePassword
+    /**
+     * The token for downloading the suppression file(s) from HTTP Bearer protected locations
+     */
+    String suppressionFileBearerToken
     /**
      * The path to the hints file.
      */

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/HostedSuppressionsExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/HostedSuppressionsExtension.groovy
@@ -13,6 +13,18 @@ class HostedSuppressionsExtension {
      */
     String url
     /**
+     * Credentials used for basic authentication for a mirrored hosted suppressions file.
+     */
+    String user
+    /**
+     * Credentials used for basic authentication for a mirrored hosted suppressions file.
+     */
+    String password
+    /**
+     * Credentials used for bearer authentication for a mirrored hosted suppressions file.
+     */
+    String bearerToken
+    /**
      * Whether the hosted suppressions file should be updated regardless of the `autoupdate` setting.
      */
     Boolean forceupdate

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/KEVExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/KEVExtension.groovy
@@ -1,0 +1,28 @@
+package org.owasp.dependencycheck.gradle.extension
+
+class KEVExtension {
+    /**
+     * Sets whether the Known Exploited Vulnerability update and Analyzer will be used.
+     */
+    Boolean enabled
+    /**
+     * URL to the CISA Known Exploited Vulnerabilities JSON data feed.
+     */
+    String url
+    /**
+     * Credentials used for basic authentication for the CISA Known Exploited Vulnerabilities JSON data feed.
+     */
+    String user
+    /**
+     * Credentials used for basic authentication for the CISA Known Exploited Vulnerabilities JSON data feed.
+     */
+    String password
+    /**
+     * Credentials used for bearer authentication for the CISA Known Exploited Vulnerabilities JSON data feed.
+     */
+    String bearerToken
+    /**
+     * Controls the skipping of the check for Known Exploited Vulnerabilities updates.
+     */
+    Integer validForHours
+}

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NvdExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/NvdExtension.groovy
@@ -49,6 +49,10 @@ class NvdExtension {
      */
     String datafeedPassword
     /**
+     * Credentials used for bearer authentication for the NVD API Data feed.
+     */
+    String datafeedBearerToken
+    /**
      * The number of hours to wait before checking for new updates from the NVD. The default is 4 hours.
      */
     Integer validForHours

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/extension/RetireJSExtension.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/extension/RetireJSExtension.groovy
@@ -40,6 +40,18 @@ class RetireJSExtension {
      */
     String retireJsUrl
     /**
+     * Credentials used for basic authentication for the Retire JS Repository URL.
+     */
+    String user
+    /**
+     * Credentials used for basic authentication for the Retire JS Repository URL.
+     */
+    String password
+    /**
+     * Credentials used for bearer authentication for the Retire JS Repository URL.
+     */
+    String bearerToken
+    /**
      * Whether the Retire JS analyzer should be updated regardless of the `autoupdate` setting.
      */
     Boolean forceupdate

--- a/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
+++ b/src/main/groovy/org/owasp/dependencycheck/gradle/tasks/ConfiguredTask.groovy
@@ -74,6 +74,7 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setArrayIfNotEmpty(SUPPRESSION_FILE, suppressionLists)
         settings.setStringIfNotEmpty(SUPPRESSION_FILE_USER, config.suppressionFileUser)
         settings.setStringIfNotEmpty(SUPPRESSION_FILE_PASSWORD, config.suppressionFilePassword)
+        settings.setStringIfNotEmpty(SUPPRESSION_FILE_BEARER_TOKEN, config.suppressionFileBearerToken)
         settings.setStringIfNotEmpty(HINTS_FILE, config.hintsFile)
 
         configureProxy(settings)
@@ -101,12 +102,16 @@ abstract class ConfiguredTask extends DefaultTask {
             settings.setStringIfNotEmpty(NVD_API_DATAFEED_USER, config.nvd.datafeedUser)
             settings.setStringIfNotEmpty(NVD_API_DATAFEED_PASSWORD, config.nvd.datafeedPassword)
         }
+        settings.setStringIfNotEmpty(NVD_API_DATAFEED_BEARER_TOKEN, config.nvd.datafeedBearerToken)
 
         settings.setBooleanIfNotNull(DOWNLOADER_QUICK_QUERY_TIMESTAMP, config.quickQueryTimestamp)
         settings.setFloat(JUNIT_FAIL_ON_CVSS, config.junitFailOnCVSS)
         settings.setBooleanIfNotNull(HOSTED_SUPPRESSIONS_ENABLED, config.hostedSuppressions.enabled)
         settings.setBooleanIfNotNull(HOSTED_SUPPRESSIONS_FORCEUPDATE, config.hostedSuppressions.forceupdate)
         settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_URL, config.hostedSuppressions.url)
+        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_USER, config.hostedSuppressions.user)
+        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_PASSWORD, config.hostedSuppressions.password)
+        settings.setStringIfNotNull(HOSTED_SUPPRESSIONS_BEARER_TOKEN, config.hostedSuppressions.bearerToken)
         if (config.hostedSuppressions.validForHours != null) {
             if (config.hostedSuppressions.validForHours >= 0) {
                 settings.setInt(HOSTED_SUPPRESSIONS_VALID_FOR_HOURS, config.hostedSuppressions.validForHours)
@@ -131,9 +136,12 @@ abstract class ConfiguredTask extends DefaultTask {
 
         settings.setBooleanIfNotNull(ANALYZER_EXPERIMENTAL_ENABLED, config.analyzers.experimentalEnabled)
         settings.setBooleanIfNotNull(ANALYZER_ARCHIVE_ENABLED, config.analyzers.archiveEnabled)
-        settings.setBooleanIfNotNull(ANALYZER_KNOWN_EXPLOITED_ENABLED, config.analyzers.knownExploitedEnabled)
-        settings.setStringIfNotNull(KEV_URL, config.analyzers.knownExploitedURL)
-        settings.setIntIfNotNull(KEV_CHECK_VALID_FOR_HOURS, config.analyzers.knownExploitedValidForHours)
+        settings.setBooleanIfNotNull(ANALYZER_KNOWN_EXPLOITED_ENABLED, config.analyzers.kev.enabled)
+        settings.setStringIfNotNull(KEV_URL, config.analyzers.kev.url)
+        settings.setIntIfNotNull(KEV_CHECK_VALID_FOR_HOURS, config.analyzers.kev.validForHours)
+        settings.setStringIfNotNull(KEV_USER, config.analyzers.kev.user)
+        settings.setStringIfNotNull(KEV_PASSWORD, config.analyzers.kev.password)
+        settings.setStringIfNotNull(KEV_BEARER_TOKEN, config.analyzers.kev.bearerToken)
         settings.setStringIfNotEmpty(ADDITIONAL_ZIP_EXTENSIONS, config.analyzers.zipExtensions)
         settings.setBooleanIfNotNull(ANALYZER_ASSEMBLY_ENABLED, config.analyzers.assemblyEnabled)
         settings.setBooleanIfNotNull(ANALYZER_MSBUILD_PROJECT_ENABLED, config.analyzers.msbuildEnabled)
@@ -173,6 +181,9 @@ abstract class ConfiguredTask extends DefaultTask {
         settings.setBooleanIfNotNull(ANALYZER_RETIREJS_ENABLED, config.analyzers.retirejs.enabled)
         settings.setBooleanIfNotNull(ANALYZER_RETIREJS_FORCEUPDATE, config.analyzers.retirejs.forceupdate)
         settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_URL, config.analyzers.retirejs.retireJsUrl)
+        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_USER, config.analyzers.retirejs.user)
+        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_PASSWORD, config.analyzers.retirejs.password)
+        settings.setStringIfNotNull(ANALYZER_RETIREJS_REPO_JS_BEARER_TOKEN, config.analyzers.retirejs.bearerToken)
         settings.setBooleanIfNotNull(ANALYZER_RETIREJS_FILTER_NON_VULNERABLE, config.analyzers.retirejs.filterNonVulnerable)
         settings.setArrayIfNotEmpty(ANALYZER_RETIREJS_FILTERS, config.analyzers.retirejs.filters)
 

--- a/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
+++ b/src/test/groovy/org/owasp/dependencycheck/gradle/DependencyCheckGradlePluginSpec.groovy
@@ -127,9 +127,11 @@ class DependencyCheckGradlePluginSpec extends Specification {
                     url = 'https://example.com/artifacgtory'
                     bearerToken = 'abc123=='
                 }
-                knownExploitedEnabled = false
-                knownExploitedURL = "https://example.com"
-                knownExploitedValidForHours = 12
+                kev {
+                    enabled = false
+                    url = "https://example.com"
+                    validForHours = 12
+                }
                 retirejs {
                     filters = ['filter1', 'filter2']
                     filterNonVulnerable = true
@@ -199,8 +201,8 @@ class DependencyCheckGradlePluginSpec extends Specification {
         project.dependencyCheck.analyzers.artifactory.enabled == true
         project.dependencyCheck.analyzers.artifactory.url == 'https://example.com/artifacgtory'
         project.dependencyCheck.analyzers.artifactory.bearerToken == 'abc123=='
-        project.dependencyCheck.analyzers.knownExploitedEnabled == false
-        project.dependencyCheck.analyzers.knownExploitedURL == "https://example.com"
+        project.dependencyCheck.analyzers.kev.enabled == false
+        project.dependencyCheck.analyzers.kev.url == "https://example.com"
         project.dependencyCheck.analyzers.retirejs.filters == ['filter1', 'filter2']
         project.dependencyCheck.analyzers.retirejs.filterNonVulnerable == true
         project.dependencyCheck.slack.enabled == true


### PR DESCRIPTION
Implement bearer-authentication and add basic authentication options to onboard on the changes of https://github.com/jeremylong/DependencyCheck/pull/7277

* Extend NVD API datafeed authentication configuration with bearer
* Move KEV configuration to an extension
* Enable KEV mirror authentication configuration (both basic and bearer)
* Extend suppression files authentication configuration bearer
* Enable hostedSuppressions mirror authentication configuration (both basic and bearer)
* Enable RetireJS mirror authentication configuration(both basic and bearer)

## Related issues
Fixes https://github.com/jeremylong/DependencyCheck/issues/7131